### PR TITLE
Open manual implementation

### DIFF
--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -4,6 +4,8 @@ import "./WelcomePage.css";
 const WelcomePage: React.FC = () => {
 	const handleOpenManual = () => {
 		console.log("Open Manual");
+		// Manual V1.9 from E3DA website
+		window.open('https://e3da.csce.uark.edu/release/PowerSynth/manual/PowerSynth_v1.9.pdf', '_blank');
 	};
 
 	const handleCreateProject = () => {


### PR DESCRIPTION
Added to the handleOpenManual function to open the manual from the E3DA website. Just uses a simple window.open to open the link in a new tab.