### PR TITLE
Implemented starting GUI for Edit Constraints page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
+        "react-tabs": "^6.0.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }
@@ -5404,6 +5405,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14063,6 +14072,18 @@
         }
       }
     },
+    "node_modules/react-tabs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.0.0.tgz",
+      "integrity": "sha512-8jKLKrlwxmn5/+xsa76yi27ZdB8E/WhlhQZw739O5UlOeUGtVoVeWnpqIewv/KbjTw7gQf/uA51zWUNt4IVygQ==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -20644,6 +20665,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -26720,6 +26746,15 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-tabs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.0.0.tgz",
+      "integrity": "sha512-8jKLKrlwxmn5/+xsa76yi27ZdB8E/WhlhQZw739O5UlOeUGtVoVeWnpqIewv/KbjTw7gQf/uA51zWUNt4IVygQ==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "react-tabs": "^6.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import './App.css';
 
 import WelcomePage from './components/WelcomePage';
+import EditConstraints from './components/EditConstraints';
 
 const App: React.FC = () => {
   return (
     <div>
       <WelcomePage />
+      {/* <EditConstraints /> */}
     </div>
   );
 };

--- a/src/components/EditConstraints.css
+++ b/src/components/EditConstraints.css
@@ -1,0 +1,62 @@
+.edit-constraints {
+  background-color: white;
+  display: flex;
+	flex-direction: column;
+}
+
+.edit-constraints h2 {
+  margin-top: 10px;
+  margin-bottom: 0px;
+  margin-left: 30px;
+  margin-right: 30px;
+}
+
+.edit-constraints h3 {
+  margin-top: 5px;
+  font-weight: lighter;
+  margin-left: 30px;
+  margin-right: 30px;
+}
+
+button {
+  padding: 10px 20px;
+  font-size: 18px;
+  cursor: pointer;
+
+  position:absolute;
+  bottom: 15px;
+  right: 15px;
+}
+  
+
+
+/* Min Dimensions Tab */
+.min-dimensions {
+  border: 1px solid;
+  border-color:rgb(175, 175, 175);
+  height: 300px;
+  width: 80%;
+  overflow: auto;
+  margin-left: 30px;
+  margin-right: 30px;
+}
+
+.min-dimensions table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid;
+  margin-right: 150px;
+}
+
+.min-dimensions th, td {
+  border: 1px solid;
+  border-color: gray;
+}
+
+.min-dimensions th, .cellCorner {
+  background-color: lightgray;
+}
+
+.cellCorner {
+  border-right-color: lightgray;
+}

--- a/src/components/EditConstraints.tsx
+++ b/src/components/EditConstraints.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import 'react-tabs/style/react-tabs.css'; // Default Tab styling from react-tabs package, will change later
+import "./EditConstraints.css";
+
+const EditConstraints: React.FC = () => {
+  // arrays for all future headers for other tabs from constraints.csv, otehrs will be implemented later
+  const minDimHeader = ["EMPTY", "power_trace", "signal_trace", "bonding wire pad", "power_lead", "signal_lead", "MOS", "cap"];
+  /*
+  const HorEncHeader = [];
+  const VerEncHeader = [];
+  const HorSpaHeader = [];
+  const VerSpaHeader = [];
+  */
+
+  // default values include vertical headers due to what I used to input data into cells
+  const MinDimDefaultValues = [
+    {ROW: "MinWidth", EMPTY: 1, power_trace: 1, signal_trace: 1, bonding_wire_pad: 0, power_lead: 3.0, signal_lead: 1.0, MOS: 4.0, cap: 6.0 }, 
+    {ROW: "MinLength", EMPTY: 1, power_trace: 1, signal_trace: 1, bonding_wire_pad: 0, power_lead: 3.0, signal_lead: 1.0, MOS: 6.0, cap: 2.0 },
+    {ROW: "MinHorExtension", EMPTY: 1, power_trace: 1, signal_trace: 1, bonding_wire_pad: 0, power_lead: 3.0, signal_lead: 1.0, MOS: 4.0, cap: 6.0 },
+    {ROW: "MinVerExtension", EMPTY: 1, power_trace: 1, signal_trace: 1, bonding_wire_pad: 0, power_lead: 3.0, signal_lead: 1.0, MOS: 6.0, cap: 2.0 }
+  ];
+
+  const handleConstraintsContinue = () => { 
+    console.log("Edit Constraints Continue")
+  }; 
+
+  return (
+    <div className="edit-constraints">
+      <h2> Edit Constraints </h2>
+      <h3> Please edit the values in the constraints.csv file, then click continue. </h3>
+      
+      {/* react-tabs implementation */}
+      <Tabs defaultIndex={0} onSelect={(index) => console.log(index)}>
+        
+        {/* Names for tabs */}
+        <TabList>  
+          <Tab>Min Dimensions</Tab>
+          <Tab>MinHorEnclosure</Tab>
+          <Tab>MinVerEnclosure</Tab>
+          <Tab>MinhorSpacing</Tab>
+          <Tab>MinVerSpacing</Tab>
+        </TabList>
+
+        {/* TabPanel is where contents of each tab need to be placed */}
+        <TabPanel> 
+          <div className="min-dimensions">
+            <table>
+              <tr>
+                <td className="cellCorner"></td> {/* Modify corner to look cleaner */}
+                {minDimHeader.map((rows) => {
+                  return <th scope="col">{rows}</th>
+                })}
+              </tr>
+              
+              {/* Input all data rows */}
+              {MinDimDefaultValues.map((val, key)=> {
+                return (
+                  <tr key={key}>
+                    <th>{val.ROW} </th>
+                    <td>{val.EMPTY}</td>
+                    <td>{val.power_trace}</td>
+                    <td>{val.signal_trace}</td>
+                    <td>{val.bonding_wire_pad}</td>
+                    <td>{val.power_lead}</td>
+                    <td>{val.signal_lead}</td>
+                    <td>{val.MOS}</td>
+                    <td>{val.cap}</td>
+                  </tr>
+                )})}
+            </table>
+          </div>
+        {/* Rest of panels can be implemented later with their respective data */}
+        </TabPanel>
+        <TabPanel>
+          <h2> MinHorEnclosure </h2>
+        </TabPanel>
+        <TabPanel>
+          <h2> MinVerEnclosure </h2>
+        </TabPanel>
+        <TabPanel>
+          <h2> MinHorSpacing </h2>
+        </TabPanel>
+        <TabPanel>
+          <h2> MinVerSpacing </h2>
+        </TabPanel>
+
+      </Tabs>
+      
+      {/* Later implement handle to go to next page */}
+      <button onClick={handleConstraintsContinue}>Continue</button>
+    </div>
+  );
+
+
+};
+
+export default EditConstraints;


### PR DESCRIPTION
## Describe your changes
Implemented initial GUI for the Edit Constraints window, also currently read only but will need to be editable in the future.
Only first default tab has the table with default data, rest have placeholder text and will add later to match the constraints.csv default data. 
Added 'react-tabs' package to easily make tabs, used default CSS style that came with it, will change later. 

## Issue link and documentation link
[📚Documentation](https://link-url-here.org)
[💻Issue](https://link-url-here.org)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added the necessary documentation.
